### PR TITLE
Add setup.py for packaging offline Zotero Assistant

### DIFF
--- a/pipeline/science/features_lab/offline_chatbot/setup.py
+++ b/pipeline/science/features_lab/offline_chatbot/setup.py
@@ -1,0 +1,41 @@
+from setuptools import setup, find_packages
+
+with open("README.md", "r", encoding="utf-8") as fh:
+    long_description = fh.read()
+
+with open("requirements_streamlit.txt", "r", encoding="utf-8") as fh:
+    requirements = [line.strip() for line in fh if line.strip() and not line.startswith("#")]
+
+setup(
+    name="offline-zotero-assistant",
+    version="1.0.0",
+    author="Your Name",
+    author_email="your-email@example.com",
+    description="An offline Zotero research assistant using semantic search",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url="https://github.com/yourusername/offline-zotero-assistant",
+    packages=find_packages(),
+    classifiers=[
+        "Development Status :: 4 - Beta",
+        "Intended Audience :: Science/Research",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Topic :: Scientific/Engineering :: Artificial Intelligence",
+        "Topic :: Software Development :: Libraries :: Python Modules",
+    ],
+    python_requires=">=3.8",
+    install_requires=requirements,
+    entry_points={
+        "console_scripts": [
+            "zotero-assistant=simple_test:main",
+        ],
+    },
+    include_package_data=True,
+    zip_safe=False,
+) 


### PR DESCRIPTION
This commit adds a setup.py file to enable packaging and distribution of the Offline Zotero Assistant as a Python module.

Key features:
- Reads project metadata from README.md and requirements_streamlit.txt
- Specifies metadata such as name, author, license, and classifiers
- Uses setuptools to support packaging and PyPI compatibility
- Includes entry point for running the assistant via console command: `zotero-assistant`
- Supports Python 3.8 to 3.11 and marks project as MIT-licensed and intended for research use