### PR TITLE
fix: bug of source display

### DIFF
--- a/pipeline/science/pipeline/rag_agent.py
+++ b/pipeline/science/pipeline/rag_agent.py
@@ -188,11 +188,13 @@ async def get_rag_context(chat_session: ChatSession, file_path_list, question: Q
     if chat_session.mode == ChatMode.BASIC or chat_session.mode == ChatMode.ADVANCED:
         logger.info(f"Current mode is {chat_session.mode}")
         try:
-            logger.info(f"Loading markdown embeddings from {[os.path.join(embedding_folder, 'markdown') for embedding_folder in embedding_folder_list]}")
-            markdown_embedding_folder_list = [os.path.join(embedding_folder, 'markdown') for embedding_folder in embedding_folder_list]
-            db = load_embeddings(markdown_embedding_folder_list, 'default')
+            logger.info(f"Loading markdown embeddings from {[os.path.join(embedding_folder, 'markdown', 'page_based_index') for embedding_folder in embedding_folder_list]}")
+            # Fix: Page-based embeddings are saved under markdown/page_based_index subfolder
+            pagebased_embedding_folder_list = [os.path.join(embedding_folder, 'markdown', 'page_based_index') for embedding_folder in embedding_folder_list]
+            db = load_embeddings(pagebased_embedding_folder_list, 'default')
         except Exception as e:
             logger.exception(f"Failed to load markdown embeddings for deep thinking mode: {str(e)}")
+            # Fallback to main embedding folder if page_based_index doesn't exist
             db = load_embeddings(embedding_folder_list, 'default')
     # === STEP 2b: Lite Mode Handling ===
     # Handle Lite mode in other cases - uses lightweight embeddings
@@ -332,6 +334,7 @@ async def get_rag_context(chat_session: ChatSession, file_path_list, question: Q
         # Load page-based embeddings based on the current mode
         if chat_session.mode == ChatMode.BASIC or chat_session.mode == ChatMode.ADVANCED:
             logger.info(f"Loading page-based embeddings for {chat_session.mode} mode")
+            # Fix: Page-based embeddings are saved under markdown/page_based_index subfolder
             page_embedding_folder_list = [os.path.join(embedding_folder, 'markdown', 'page_based_index') for embedding_folder in embedding_folder_list]
             page_db = load_embeddings(page_embedding_folder_list, 'default')
         else:  # ChatMode.LITE

--- a/pipeline/science/pipeline/sources_retrieval.py
+++ b/pipeline/science/pipeline/sources_retrieval.py
@@ -62,7 +62,7 @@ def normalize_text(text, remove_linebreaks=True):
     return text.strip()
 
 
-def locate_chunk_in_pdf(chunk: str, pdf_path: str, similarity_threshold: float = 0.8, remove_linebreaks: bool = False) -> dict:
+def locate_chunk_in_pdf(chunk: str, source_page_number: int, pdf_path: str, similarity_threshold: float = 0.8, remove_linebreaks: bool = False) -> dict:
     """
     Locates a text chunk within a PDF file and returns its position information.
     Uses both exact matching and fuzzy matching for robustness.
@@ -88,7 +88,24 @@ def locate_chunk_in_pdf(chunk: str, pdf_path: str, similarity_threshold: float =
         "success": False,
         "similarity": 0.0
     }
-    
+    logger.info(f"TEST: CODE0745 source_page_number: {source_page_number}, chunk: {chunk}")
+    if (source_page_number is not None) and (chunk is not None) and (chunk.strip() != ""):
+        result = {
+            "page_num": int(source_page_number),
+            "start_char": 1,
+            "end_char": 2,
+            "success": True,
+            "similarity": 1.0
+        }
+        return result
+    else:
+        return result
+
+    # NOTE: following the revision on source button generation logic, we 
+    # no longer output smaller chunk, but the entire pages, so we don't need to 
+    # search for the chunk, but we just need to get the page number;
+    # Therefore, we currently implement a simple version that just returns the actualpage number
+    # and avoid the following logic for simplicity and avoid bug of always returning first page
     try:
         # Normalize the search chunk
         normalized_chunk = normalize_text(chunk, remove_linebreaks)

--- a/pipeline/science/pipeline/tutor_agent_advanced.py
+++ b/pipeline/science/pipeline/tutor_agent_advanced.py
@@ -427,7 +427,8 @@ async def tutor_agent_advanced_streaming(chat_session: ChatSession, file_path_li
         _doc = process_pdf_file(file_path_list[index-1])[1]
         # annotations, _ = get_highlight_info(_doc, [source])
         # logger.info(f"TEST: source: {source}, index: {index}, file_path: {file_path_list[refined_source_index[source]]}")
-        annotations = locate_chunk_in_pdf(source, file_path_list[refined_source_index[source]])
+        source_page_number = source_pages.get(source)
+        annotations = locate_chunk_in_pdf(source, source_page_number, file_path_list[refined_source_index[source]])
         source_annotations[source] = annotations
         logger.info(f"For source number {i}, the annotations extraction is: {annotations}")
         i += 1

--- a/pipeline/science/pipeline/tutor_agent_basic.py
+++ b/pipeline/science/pipeline/tutor_agent_basic.py
@@ -386,6 +386,7 @@ async def tutor_agent_basic_streaming(chat_session: ChatSession, file_path_list,
         chat_history=chat_history,
         embedding_folder_list=embedding_folder_list
     )
+    logger.info(f"TEST: CODE0790 source_pages: {source_pages.values()}, refined_source_pages: {refined_source_pages.values()}, refined_source_index: {refined_source_index.values()}")
 
     for source_key, source_value in sources.items():
         yield "<source>"
@@ -439,7 +440,8 @@ async def tutor_agent_basic_streaming(chat_session: ChatSession, file_path_list,
         _doc = process_pdf_file(file_path_list[index-1])[1]
         # annotations, _ = get_highlight_info(_doc, [source])
         # logger.info(f"TEST: source: {source}, index: {index}, file_path: {file_path_list[refined_source_index[source]]}")
-        annotations = locate_chunk_in_pdf(source, file_path_list[refined_source_index[source]])
+        source_page_number = source_pages.get(source)
+        annotations = locate_chunk_in_pdf(source, source_page_number, file_path_list[refined_source_index[source]])
         source_annotations[source] = annotations
         logger.info(f"For source number {i}, the annotations extraction is: {annotations}")
         i += 1

--- a/pipeline/science/pipeline/tutor_agent_lite.py
+++ b/pipeline/science/pipeline/tutor_agent_lite.py
@@ -336,7 +336,8 @@ async def tutor_agent_lite_streaming(chat_session: ChatSession, file_path_list, 
         _doc = process_pdf_file(file_path_list[index-1])[1]
         # annotations, _ = get_highlight_info(_doc, [source])
         # logger.info(f"TEST: source: {source}, index: {index}, file_path: {file_path_list[refined_source_index[source]]}")
-        annotations = locate_chunk_in_pdf(source, file_path_list[refined_source_index[source]])
+        source_page_number = source_pages.get(source)
+        annotations = locate_chunk_in_pdf(source, source_page_number, file_path_list[refined_source_index[source]])
         source_annotations[source] = annotations
         logger.info(f"For source number {i}, the annotations extraction is: {annotations}")
         i += 1


### PR DESCRIPTION
Attempt to resolve the issue of source button issue for a specific test document (which has a lot of image and formulas)
-Researched the board scope of codebase, especially highlight code section 
-Initially thought to be source objects attribute error
-Then, consider the chance of embedding issue, namely FAISS save_local failing to save metadata
-Next, process to assume the formal reason being that the load embedding error that led to fallback action; we tolerated this error before as the tests were performing well, but maybe this is the main reason